### PR TITLE
Add new method saveObjectsWithLimit() to class AmoAPI

### DIFF
--- a/src/AmoCRM/AmoAPI.php
+++ b/src/AmoCRM/AmoAPI.php
@@ -59,6 +59,17 @@ class AmoAPI
         return $response['_embedded']['items'] ?? null;
     }
 
+    /* Сохраняет объекты пачками, с учетом лимита */
+    public static function saveObjectsWithLimit($amoObjects, bool $returnResponses = false, $subdomain = null, $limit = 250) :array {
+        if(count($amoObjects) < $limit) return self::saveObjects($amoObjects, $returnResponses, $subdomain);
+        $out = array();
+        $amoObjectsChunks = array_chunk($amoObjects, $limit);
+        foreach ($amoObjectsChunks as $amoObjectsChunk) {
+            $out = array_merge($out, self::saveObjects($amoObjectsChunk, $returnResponses, $subdomain));
+        }
+        return  $out;
+    }
+    
     /**
      * Сохраняет (добавляет или обновляет) объекты AmoObject
      * @param array $amoObjects Массив объектов


### PR DESCRIPTION
- `saveObjectsWithLimit($amoObjects, bool $returnResponses = false, $subdomain = null, int $limit = 250) :array`  
    Сохраняет (добавляет или обновляет) объекты AmoObject с ограничением на число сущностей в одном запросе к  amoCRM.